### PR TITLE
Fix sporadic test failure because of improper diff on embedded map

### DIFF
--- a/cmd/cephctl/main.go
+++ b/cmd/cephctl/main.go
@@ -12,6 +12,7 @@ import (
 	diffCmd "github.com/teran/cephctl/commands/diff"
 	dumpCephConfigCmd "github.com/teran/cephctl/commands/dump/cephconfig"
 	healthcheckCmd "github.com/teran/cephctl/commands/healthcheck"
+	"github.com/teran/cephctl/differ"
 	"github.com/teran/cephctl/service"
 )
 
@@ -66,7 +67,7 @@ func main() {
 		log.Debug("Debug mode is enabled. Beware of verbosity!")
 	}
 
-	svc := service.New(ceph.New(*cephBinary))
+	svc := service.New(ceph.New(*cephBinary), differ.New())
 
 	switch appCmd {
 	case apply.FullCommand():

--- a/differ/differ.go
+++ b/differ/differ.go
@@ -1,0 +1,101 @@
+package differ
+
+import (
+	"context"
+	"strings"
+
+	"github.com/pkg/errors"
+	diff "github.com/r3labs/diff/v3"
+	log "github.com/sirupsen/logrus"
+	"github.com/teran/go-ptr"
+
+	"github.com/teran/cephctl/models"
+)
+
+const flattenMapSeparator = ":::"
+
+type Differ interface {
+	DiffCephConfig(ctx context.Context, from, to models.CephConfig) ([]models.CephConfigDifference, error)
+}
+
+type differ struct{}
+
+func New() Differ {
+	return &differ{}
+}
+
+func (d *differ) DiffCephConfig(ctx context.Context, from, to models.CephConfig) ([]models.CephConfigDifference, error) {
+	srcf := flattenMap(from)
+	cfgf := flattenMap(to)
+
+	changelog, err := diff.Diff(srcf, cfgf)
+	if err != nil {
+		return nil, errors.Wrap(err, "error comparing current and desired configuration")
+	}
+
+	log.Tracef("diff generated: %#v", changelog)
+
+	changes := []models.CephConfigDifference{}
+	for _, change := range changelog {
+		pathParts := strings.SplitN(change.Path[0], flattenMapSeparator, 2)
+		section := pathParts[0]
+		key := pathParts[1]
+
+		switch change.Type {
+		case diff.CREATE:
+			v, ok := change.To.(string)
+			if !ok {
+				log.Warnf("unexpected value type: expected string, got %T", v)
+				break
+			}
+
+			changes = append(changes, models.CephConfigDifference{
+				Kind:    models.CephConfigDifferenceKindAdd,
+				Section: section,
+				Key:     key,
+				Value:   ptr.String(v),
+			})
+
+		case diff.UPDATE:
+			oldV, ok := change.From.(string)
+			if !ok {
+				log.Warnf("unexpected old value type: expected string, got %T", oldV)
+				break
+			}
+
+			v, ok := change.To.(string)
+			if !ok {
+				log.Warnf("unexpected new value type: expected string, got %T", v)
+				break
+			}
+
+			changes = append(changes, models.CephConfigDifference{
+				Kind:     models.CephConfigDifferenceKindChange,
+				Section:  section,
+				Key:      key,
+				OldValue: ptr.String(oldV),
+				Value:    ptr.String(v),
+			})
+
+		case diff.DELETE:
+			changes = append(changes, models.CephConfigDifference{
+				Kind:    models.CephConfigDifferenceKindRemove,
+				Section: section,
+				Key:     key,
+			})
+
+		}
+	}
+
+	return changes, nil
+}
+
+func flattenMap(in map[string]map[string]string) map[string]string {
+	out := make(map[string]string)
+	for k, v := range in {
+		for j, m := range v {
+			out[k+flattenMapSeparator+j] = m
+		}
+	}
+	return out
+}

--- a/differ/differ_test.go
+++ b/differ/differ_test.go
@@ -1,0 +1,91 @@
+package differ
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"github.com/teran/cephctl/models"
+	ptr "github.com/teran/go-ptr"
+)
+
+func (s *differTestSuite) TestDiffCephConfig() {
+	from := models.CephConfig{
+		"osd": {
+			"test_key": "value",
+		},
+		"osd.3": {
+			"test_key": "old_value",
+		},
+	}
+	to := models.CephConfig{
+		"mon": {
+			"test_key": "value",
+		},
+		"osd.3": {
+			"test_key": "value",
+		},
+	}
+
+	diff, err := s.differ.DiffCephConfig(s.ctx, from, to)
+	s.Require().NoError(err)
+	s.Require().ElementsMatch([]models.CephConfigDifference{
+		{
+			Kind:    models.CephConfigDifferenceKindAdd,
+			Section: "mon",
+			Key:     "test_key",
+			Value:   ptr.String("value"),
+		},
+		{
+			Kind:     models.CephConfigDifferenceKindChange,
+			Section:  "osd.3",
+			Key:      "test_key",
+			OldValue: ptr.String("old_value"),
+			Value:    ptr.String("value"),
+		},
+		{
+			Kind:    models.CephConfigDifferenceKindRemove,
+			Section: "osd",
+			Key:     "test_key",
+		},
+	}, diff)
+}
+
+type differTestSuite struct {
+	suite.Suite
+
+	ctx    context.Context
+	differ Differ
+}
+
+func (s *differTestSuite) SetupTest() {
+	s.ctx = context.TODO()
+	s.differ = New()
+}
+
+func (s *differTestSuite) TearDownTest() {
+	s.ctx = nil
+	s.differ = nil
+}
+
+func TestDifferTestSuite(t *testing.T) {
+	suite.Run(t, &differTestSuite{})
+}
+
+func TestFlattenMap(t *testing.T) {
+	r := require.New(t)
+
+	out := flattenMap(map[string]map[string]string{
+		"key1": {
+			"key2": "value3",
+		},
+		"key3": {
+			"key4": "value5",
+		},
+	})
+	r.Equal(map[string]string{
+		"key1:::key2": "value3",
+		"key3:::key4": "value5",
+	}, out)
+}

--- a/differ/mock.go
+++ b/differ/mock.go
@@ -1,0 +1,23 @@
+package differ
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/teran/cephctl/models"
+)
+
+var _ Differ = (*Mock)(nil)
+
+type Mock struct {
+	mock.Mock
+}
+
+func NewMock() *Mock {
+	return &Mock{}
+}
+
+func (m *Mock) DiffCephConfig(ctx context.Context, from, to models.CephConfig) ([]models.CephConfigDifference, error) {
+	args := m.Called(from, to)
+	return args.Get(0).([]models.CephConfigDifference), args.Error(1)
+}


### PR DESCRIPTION
Sometimes tests could fail because of improper changelong result on complex structures like `map[string]map[string]string`.

Now diff functionality is wrapped and this use case is worked around via flattening the structure.

Ref: https://github.com/r3labs/diff/issues/95