### PR TITLE
Add some metadata to trunk build & remove excess metadata from goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,7 +4,7 @@ builds:
     main: ./cmd/cephctl
     binary: cephctl
     ldflags:
-      - -s -w -X main.appVersion={{.Version}} -X main.buildTimestamp={{.Date}} -X main.commitTimestamp={{.CommitTimestamp}} -X main.gitCommit={{.ShortCommit}}
+      - -s -w -X main.appVersion={{.Version}} -X main.buildTimestamp={{.Date}}
     env:
       - CGO_ENABLED=0
     goos:

--- a/README.md
+++ b/README.md
@@ -107,9 +107,11 @@ Container image is available at [GitHub Packages](https://github.com/teran/cephc
 
 ### Build from source
 
-It's possible to build cephctl from source by simply running the follwoing
+It's possible to build cephctl from source by simply running the following
 command:
 
+<!-- markdownlint-disable MD013 -->
 ```shell
-go build -o dist/cephctl ./cmd/cephctl/...
+go build -v -ldflags="-X 'main.appVersion=$(git rev-parse --short HEAD) (trunk build)' -X 'main.buildTimestamp=$(date -u +%Y-%m-%dT%H:%m:%SZ)'" -o dist/cephctl ./cmd/cephctl/...
 ```
+<!-- markdownlint-enable MD013 -->


### PR DESCRIPTION
Adding build metadata to trunk build allows to identify it so it's really useful on further troubleshooting.
In addition .goreleaser.yml contained some excess metadata which is not supported in main.go.