### PR TITLE
Add clean diff indication for multidoc specs

### DIFF
--- a/commands/diff/diff.go
+++ b/commands/diff/diff.go
@@ -40,6 +40,10 @@ func Diff(ctx context.Context, ac DiffConfig) error {
 				return err
 			}
 
+			if len(descs) > 1 && len(changes) > 0 {
+				ac.Printer.Printf("%s:\n", desc.Kind)
+			}
+
 			for _, change := range changes {
 				log.WithFields(log.Fields{
 					"component": "command",
@@ -64,6 +68,10 @@ func Diff(ctx context.Context, ac DiffConfig) error {
 			changes, err := ac.Service.DiffCephOSDConfig(ctx, cfg)
 			if err != nil {
 				return err
+			}
+
+			if len(descs) > 1 && len(changes) > 0 {
+				ac.Printer.Printf("%s:\n", desc.Kind)
 			}
 
 			for _, change := range changes {

--- a/commands/diff/testdata/multidoc.yaml
+++ b/commands/diff/testdata/multidoc.yaml
@@ -1,0 +1,13 @@
+---
+kind: CephConfig
+spec:
+  global:
+    test: value
+---
+kind: CephOSDConfig
+spec:
+    allow_crimson: true
+    backfillfull_ratio: 0.9
+    full_ratio: 0.95
+    nearfull_ratio: 0.85
+    require_min_compat_client: luminous

--- a/printer/mock.go
+++ b/printer/mock.go
@@ -20,6 +20,10 @@ func (m *Mock) HiRed(format string, a ...any) {
 	m.Called(format, a)
 }
 
+func (m *Mock) Printf(format string, a ...any) {
+	m.Called(format, a)
+}
+
 func (m *Mock) Println(a ...any) {
 	m.Called(a)
 }

--- a/printer/printer.go
+++ b/printer/printer.go
@@ -9,6 +9,7 @@ import (
 type Printer interface {
 	Green(format string, a ...any)
 	HiRed(format string, a ...any)
+	Printf(format string, a ...any)
 	Println(a ...any)
 	Red(format string, a ...any)
 	Yellow(format string, a ...any)
@@ -28,6 +29,10 @@ func (p *printer) Green(format string, a ...any) {
 
 func (p *printer) HiRed(format string, a ...any) {
 	color.HiRed(format, a...)
+}
+
+func (p *printer) Printf(format string, a ...any) {
+	fmt.Printf(format, a...)
 }
 
 func (p *printer) Println(a ...any) {


### PR DESCRIPTION
Just like this:

```
CephConfig:
~ global cephx_sign_messages true -> false
CephOSDConfig:
~ require_min_compat_client luminous -> reef
```

Depends on #53 