### PR TITLE
Add Ceph releases v18.2.6, v18.2.7 and v19.2.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,9 +81,12 @@ jobs:
           - '18.2.2'
           - '18.2.4'
           - '18.2.5'
+          - '18.2.6'
+          - '18.2.7'
           - '19.2.0'
           - '19.2.1'
           - '19.2.2'
+          - '19.2.3'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Since Ceph Reef reached EOL estimate on 1st of August I suppose 18.2.7 is gonna be the last Reef release supported by cephctl.